### PR TITLE
improve fragile test 

### DIFF
--- a/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
+++ b/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
@@ -14,7 +14,7 @@
  */
 package com.cloudera.exhibit.server.json;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -32,6 +32,7 @@ import com.cloudera.exhibit.core.simple.SimpleExhibit;
 import com.cloudera.exhibit.mongodb.BSONFrame;
 import com.cloudera.exhibit.mongodb.BSONObsDescriptor;
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
@@ -48,6 +49,7 @@ public class JsonTest {
 
   ObjectMapper mapper;
 
+  @SuppressWarnings("unused")
   private String expected = "{\"attrs\":{}," +
           "\"columns\":{\"t1\":[\"a\",\"b\",\"c\"],\"e\":[\"a\",\"b\",\"c\"]}," +
           "\"frames\":{\"t1\":[[1729,null,\"foo\"],[1729,3.0,null],[null,17.0,null]],\"e\":[]}}";
@@ -62,6 +64,7 @@ public class JsonTest {
     mod.addSerializer(Frame.class, new FrameSerializer());
     mod.addSerializer(ExhibitId.class, new ExhibitIdSerializer());
     mapper = new ObjectMapper();
+    mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
     mapper.registerModule(mod);
   }
 
@@ -79,7 +82,7 @@ public class JsonTest {
     AvroFrame emptyFrame = new AvroFrame(new AvroObsDescriptor(schema));
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
     final String exhibitJson = mapper.writeValueAsString(e);
-    assertTrue("incorrect json " + exhibitJson, exhibitJson.equals(expected) || exhibitJson.equals(expected2));
+    assertEquals(expected2, exhibitJson);
   }
 
   @Test
@@ -95,6 +98,6 @@ public class JsonTest {
     BSONFrame emptyFrame = new BSONFrame(d, ImmutableList.<BasicDBObject>of());
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
     final String exhibitJson = mapper.writeValueAsString(e);
-    assertTrue("incorrect json " + exhibitJson, exhibitJson.equals(expected) || exhibitJson.equals(expected2));
+    assertEquals(expected2, exhibitJson);
   }
 }

--- a/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
+++ b/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
@@ -49,11 +49,7 @@ public class JsonTest {
 
   ObjectMapper mapper;
 
-  @SuppressWarnings("unused")
   private String expected = "{\"attrs\":{}," +
-          "\"columns\":{\"t1\":[\"a\",\"b\",\"c\"],\"e\":[\"a\",\"b\",\"c\"]}," +
-          "\"frames\":{\"t1\":[[1729,null,\"foo\"],[1729,3.0,null],[null,17.0,null]],\"e\":[]}}";
-  private String expected2 = "{\"attrs\":{}," +
           "\"columns\":{\"e\":[\"a\",\"b\",\"c\"],\"t1\":[\"a\",\"b\",\"c\"]}," +
           "\"frames\":{\"e\":[],\"t1\":[[1729,null,\"foo\"],[1729,3.0,null],[null,17.0,null]]}}";
 
@@ -82,7 +78,7 @@ public class JsonTest {
     AvroFrame emptyFrame = new AvroFrame(new AvroObsDescriptor(schema));
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
     final String exhibitJson = mapper.writeValueAsString(e);
-    assertEquals(expected2, exhibitJson);
+    assertEquals(expected, exhibitJson);
   }
 
   @Test
@@ -98,6 +94,6 @@ public class JsonTest {
     BSONFrame emptyFrame = new BSONFrame(d, ImmutableList.<BasicDBObject>of());
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
     final String exhibitJson = mapper.writeValueAsString(e);
-    assertEquals(expected2, exhibitJson);
+    assertEquals(expected, exhibitJson);
   }
 }

--- a/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
+++ b/server/src/test/java/com/cloudera/exhibit/server/json/JsonTest.java
@@ -14,11 +14,19 @@
  */
 package com.cloudera.exhibit.server.json;
 
+import static org.junit.Assert.assertTrue;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.junit.Before;
+import org.junit.Test;
+
 import com.cloudera.exhibit.avro.AvroFrame;
 import com.cloudera.exhibit.avro.AvroObsDescriptor;
 import com.cloudera.exhibit.core.Exhibit;
-import com.cloudera.exhibit.core.Frame;
 import com.cloudera.exhibit.core.ExhibitId;
+import com.cloudera.exhibit.core.Frame;
 import com.cloudera.exhibit.core.ObsDescriptor;
 import com.cloudera.exhibit.core.simple.SimpleExhibit;
 import com.cloudera.exhibit.mongodb.BSONFrame;
@@ -29,13 +37,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.BasicDBObject;
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericData;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
 
 public class JsonTest {
 
@@ -50,6 +51,9 @@ public class JsonTest {
   private String expected = "{\"attrs\":{}," +
           "\"columns\":{\"t1\":[\"a\",\"b\",\"c\"],\"e\":[\"a\",\"b\",\"c\"]}," +
           "\"frames\":{\"t1\":[[1729,null,\"foo\"],[1729,3.0,null],[null,17.0,null]],\"e\":[]}}";
+  private String expected2 = "{\"attrs\":{}," +
+          "\"columns\":{\"e\":[\"a\",\"b\",\"c\"],\"t1\":[\"a\",\"b\",\"c\"]}," +
+          "\"frames\":{\"e\":[],\"t1\":[[1729,null,\"foo\"],[1729,3.0,null],[null,17.0,null]]}}";
 
   @Before
   public void setUp() throws Exception {
@@ -74,7 +78,8 @@ public class JsonTest {
     AvroFrame frame = new AvroFrame(ImmutableList.of(r1, r2, r3));
     AvroFrame emptyFrame = new AvroFrame(new AvroObsDescriptor(schema));
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
-    assertEquals(expected, mapper.writeValueAsString(e));
+    final String exhibitJson = mapper.writeValueAsString(e);
+    assertTrue("incorrect json " + exhibitJson, exhibitJson.equals(expected) || exhibitJson.equals(expected2));
   }
 
   @Test
@@ -89,6 +94,7 @@ public class JsonTest {
             new BasicDBObject(ImmutableMap.<String, Object>of("b", 17.0))));
     BSONFrame emptyFrame = new BSONFrame(d, ImmutableList.<BasicDBObject>of());
     Exhibit e = SimpleExhibit.of("t1", frame, "e", emptyFrame);
-    assertEquals(expected, mapper.writeValueAsString(e));
+    final String exhibitJson = mapper.writeValueAsString(e);
+    assertTrue("incorrect json " + exhibitJson, exhibitJson.equals(expected) || exhibitJson.equals(expected2));
   }
 }


### PR DESCRIPTION
this is due to the mapper rearranging the order of fields in the json.  i suspect this depends on fasterxml version, and perhaps jdk version as well.
