### PR TITLE
JS Compute Fixes for Spark

### DIFF
--- a/javascript/src/main/java/com/cloudera/exhibit/javascript/JSCalculator.java
+++ b/javascript/src/main/java/com/cloudera/exhibit/javascript/JSCalculator.java
@@ -34,12 +34,13 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-public class JSCalculator implements Calculator {
+public class JSCalculator implements Serializable, Calculator {
 
-  static {
+  static void initializeContextFactory() {
     ContextFactory.initGlobal(new ExhibitContextFactory());
     Context ctx = Context.enter();
     ctx.setClassShutter(new ClassShutter() {
@@ -50,15 +51,14 @@ public class JSCalculator implements Calculator {
     });
   }
 
-  private final String src;
-  private final boolean hasReturn;
+  private String src;
+  private boolean hasReturn;
 
-  private ObsDescriptor descriptor;
-
-  private Context ctx;
-  private Scriptable scope;
-  private Script script;
-  private Function func;
+  private transient ObsDescriptor descriptor;
+  private transient Context ctx;
+  private transient Scriptable scope;
+  private transient Script script;
+  private transient Function func;
 
   public JSCalculator(String src) {
     this(null, src);
@@ -73,6 +73,7 @@ public class JSCalculator implements Calculator {
   @Override
   public ObsDescriptor initialize(ExhibitDescriptor ed) {
     if (ctx == null) {
+      initializeContextFactory();
       ctx = Context.enter();
       this.scope = ctx.initStandardObjects(null, true);
       if (hasReturn) {

--- a/spark/src/main/scala/com/cloudera/exhibit/spark/ExhibitRDD.scala
+++ b/spark/src/main/scala/com/cloudera/exhibit/spark/ExhibitRDD.scala
@@ -21,6 +21,7 @@ import com.cloudera.exhibit.core.ObsDescriptor.FieldType
 import com.cloudera.exhibit.core._
 import com.cloudera.exhibit.javascript.JSCalculator
 import com.cloudera.exhibit.sql.SQLCalculator
+
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.{GenericRecord, GenericDatumReader}
 import org.apache.avro.mapred.FsInput
@@ -47,6 +48,10 @@ class ExhibitRDD private[spark](
       attrsDF = sqlContext.createDataFrame(parent.map(e => obs2row(e.attributes())), schemas._1)
     }
     return attrsDF
+  }
+
+  def frames(): Iterator[String] = {
+    descriptor.frames.keySet.iterator
   }
 
   def frame(name: String): DataFrame = {

--- a/spark/src/test/scala/com/cloudera/exhibit/spark/ExhibitRDDTest.scala
+++ b/spark/src/test/scala/com/cloudera/exhibit/spark/ExhibitRDDTest.scala
@@ -19,22 +19,22 @@ import java.io.File
 import com.google.common.collect.Lists
 import org.apache.avro.SchemaBuilder
 import org.apache.avro.file.DataFileWriter
-import org.apache.avro.generic.{GenericDatumWriter, GenericData}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.avro.generic.{GenericData, GenericDatumWriter}
 import org.apache.spark.sql.SQLContext
-import org.junit.{Before, Test, Assert}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.junit.{Assert, Before, Test}
 
 class ExhibitRDDTest {
 
   val conf = new SparkConf().setMaster("local").setAppName(getClass.getName)
   val sc = new SQLContext(new SparkContext(conf))
   val innerSchema = SchemaBuilder.record("SparkInTest").fields()
-      .optionalDouble("a").optionalString("b").optionalInt("c")
-      .endRecord()
+    .optionalDouble("a").optionalString("b").optionalInt("c")
+    .endRecord()
   val outerSchema = SchemaBuilder.record("SparkExTest").fields()
-      .optionalString("name")
-      .name("tbl").`type`().array().items(innerSchema).arrayDefault(Lists.newArrayList())
-      .endRecord()
+    .optionalString("name")
+    .name("tbl").`type`().array().items(innerSchema).arrayDefault(Lists.newArrayList())
+    .endRecord()
   var testFile: File = null
 
   @Before def setUp: Unit = {
@@ -59,9 +59,17 @@ class ExhibitRDDTest {
     dfw.close()
   }
 
-  @Test def readExhibit: Unit = {
+  @Test def readExhibitJS: Unit = {
     val erdd = ExhibitRDD.avroFile(testFile.toString, sc)
-    val defcnt = erdd.sql("""select sum(a) suma, sum(c) sumc, count(*) from tbl""")
+    val defcnt = erdd.js("tbl.length")
+    val res = defcnt.collect()
+    Assert.assertEquals(1, res.length)
+    Assert.assertEquals(2L, res(0).getLong(0))
+  }
+
+  @Test def readExhibitSQL: Unit = {
+    val erdd = ExhibitRDD.avroFile(testFile.toString, sc)
+    val defcnt = erdd.sql( """select sum(a) suma, sum(c) sumc, count(*) from tbl""")
     val res = defcnt.collect()
     Assert.assertEquals(1, res.length)
     Assert.assertEquals(32.0, res(0).getDouble(0), 0.001)

--- a/sql/src/test/java/com/cloudera/exhibit/sql/AvroTableTest.java
+++ b/sql/src/test/java/com/cloudera/exhibit/sql/AvroTableTest.java
@@ -94,25 +94,4 @@ public class AvroTableTest {
     assertEquals(null, res.get(0).get(0));
     assertEquals(1729, res.get(0).get(1));
   }
-
-  @Test
-  public void testMultipleQueries() throws Exception {
-    GenericData.Record r1 = new GenericData.Record(schema);
-    r1.put("f1", "foo");
-    r1.put("f3", 1729);
-    GenericData.Record r2 = new GenericData.Record(schema);
-    r2.put("f2", true);
-    r2.put("f3", 17);
-    AvroFrame frame = new AvroFrame(ImmutableList.of(r1, r2));
-    String[] queries = new String[] {
-        "select f2 as f2group, sum(f3) as sumf3 from t1 where f1 = 'foo' group by f2"
-      , "select sum(f3) as all_sumf3 from t1"
-    };
-    SQLCalculator calc = new SQLCalculator(queries);
-    Frame res = eval(calc, SimpleExhibit.of("t1", frame));
-    assertTrue(res.size() == 1);
-    assertEquals(null, res.get(0).get(0));
-    assertEquals(1729, res.get(0).get(1));
-  }
-
 }

--- a/sql/src/test/java/com/cloudera/exhibit/sql/AvroTableTest.java
+++ b/sql/src/test/java/com/cloudera/exhibit/sql/AvroTableTest.java
@@ -94,4 +94,25 @@ public class AvroTableTest {
     assertEquals(null, res.get(0).get(0));
     assertEquals(1729, res.get(0).get(1));
   }
+
+  @Test
+  public void testMultipleQueries() throws Exception {
+    GenericData.Record r1 = new GenericData.Record(schema);
+    r1.put("f1", "foo");
+    r1.put("f3", 1729);
+    GenericData.Record r2 = new GenericData.Record(schema);
+    r2.put("f2", true);
+    r2.put("f3", 17);
+    AvroFrame frame = new AvroFrame(ImmutableList.of(r1, r2));
+    String[] queries = new String[] {
+        "select f2 as f2group, sum(f3) as sumf3 from t1 where f1 = 'foo' group by f2"
+      , "select sum(f3) as all_sumf3 from t1"
+    };
+    SQLCalculator calc = new SQLCalculator(queries);
+    Frame res = eval(calc, SimpleExhibit.of("t1", frame));
+    assertTrue(res.size() == 1);
+    assertEquals(null, res.get(0).get(0));
+    assertEquals(1729, res.get(0).get(1));
+  }
+
 }


### PR DESCRIPTION
- Making JSCalculator serializable and adding a unit test for it.
- Added utility method to expose available frames within ExhibitRDD
